### PR TITLE
Fix battery demand scaling

### DIFF
--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -183,11 +183,22 @@ namespace Content.Server.Power.Pow3r
                     var supplyAndPassthrough = supplyCap + battery.CurrentReceiving * battery.Efficiency;
 
                     battery.AvailableSupply = Math.Min(scaledSpace, supplyAndPassthrough);
-                    battery.LoadingNetworkDemand = unmet;
 
                     battery.MaxEffectiveSupply = Math.Min(battery.CurrentStorage / frameTime, battery.MaxSupply + battery.CurrentReceiving * battery.Efficiency);
                     totalBatterySupply += battery.AvailableSupply;
                     totalMaxBatterySupply += battery.MaxEffectiveSupply;
+                }
+
+                if (totalMaxBatterySupply > 0)
+                {
+                    foreach (var batteryId in network.BatterySupplies)
+                    {
+                        var battery = state.Batteries[batteryId];
+                        if (!battery.Enabled || !battery.CanDischarge || battery.Paused)
+                            continue;
+
+                        battery.LoadingNetworkDemand = unmet * battery.MaxEffectiveSupply / totalMaxBatterySupply;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- fix bug causing parallel batteries to request the entire network demand
  - scale each battery's LoadingNetworkDemand proportional to its maximum effective output

## Testing
- `./RUN_THIS.py` *(fails: unable to clone RobustToolbox due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68464ea29db0832e9a4981145ec3225e